### PR TITLE
[Issue 19] Add Pendulum Parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 discord.py>=2.3
 APScheduler>=3.10
 python-dotenv>=1.0
+pendulum>=3.0.0
 requests>=2.32
 psycopg[binary,pool]>=3.1
 pytest>=8.0

--- a/src/components/activity_records.py
+++ b/src/components/activity_records.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timezone
 
 import discord
+import pendulum
 from discord import Interaction
 
 from src.models.activity import Activity
@@ -192,7 +193,7 @@ class RecordEditModal(discord.ui.Modal):
             max_length=500,
         )
         self.date_occurred = discord.ui.TextInput(
-            label='Date Activity Occurred (YYYY-MM-DD)',
+            label='Date Activity Occurred (i.e. YYYY-MM-DD or other standard formats)',
             style=discord.TextStyle.short,
             required=True,
             default=current_date,
@@ -207,10 +208,17 @@ class RecordEditModal(discord.ui.Modal):
         date_val = str(self.date_occurred.value).strip()
 
         try:
-            _ = date.fromisoformat(date_val)
+            # Parse the date using pendulum for flexible input
+            parsed_date = pendulum.parse(date_val, strict=False)
+            if not parsed_date:
+                raise ValueError('Could not parse date')
+            # Convert to date object and back to ISO format for consistency
+            date_val = parsed_date.date().isoformat()
         except Exception:
             await interaction.response.send_message(
-                '❌ Invalid date format. Use YYYY-MM-DD.', ephemeral=True
+                '❌ Invalid date format. '
+                'Try formats like: YYYY-MM-DD, MM/DD/YYYY, or "yesterday"',
+                ephemeral=True,
             )
             return
 

--- a/src/database/migrations/20251012_134111_populate_activities.py
+++ b/src/database/migrations/20251012_134111_populate_activities.py
@@ -14,7 +14,7 @@ ACTIVITIES = [
     ('Steps', 'Weekly Steps 35k+ (pick only one per week)', 5),
     ('Steps', 'Weekly Steps 70k+', 10),
     ('Steps', 'Weekly Steps 105k+', 15),
-    ('Steps', 'Daily Steps 140k+', 20),
+    ('Steps', 'Weekly Steps 140k+', 20),
     # === Hiking ===
     ('Hiking', '1 hour hiking', 3),
     ('Hiking', '2 hours hiking', 8),


### PR DESCRIPTION
Fixes #19 

i.e. `pendulum.parse(str, strict = false)` for manually input YYYY-MM-DD variations

Also fixing Daily Input logic error, it should no longer check if the date_occurred matches the current date for Daily Bonus credit. That's not relevant.

Also fixes a typo in the Daily Steps 140k activity, which should be Weekly Steps